### PR TITLE
refactor(eslint): turn off the `vue/multi-word-component-names` rule.

### DIFF
--- a/packages/site/.eslintrc.js
+++ b/packages/site/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "prettier",
   ],
-  rules: {},
+  rules: {
+    "vue/multi-word-component-names": "off"
+  },
 };


### PR DESCRIPTION
Now we can use single word as our component's name.